### PR TITLE
Fix the data chunking (failed with less than 1000 rows)

### DIFF
--- a/ERgene/__init__.py
+++ b/ERgene/__init__.py
@@ -14,7 +14,7 @@ from upsetplot import from_memberships
 from upsetplot import plot
 
 
-def FindERG( data, depth=2, sort_num=20):
+def FindERG(data, depth=2, sort_num=20, verbose=False):
     '''
     Find out endogenous reference gene
 
@@ -28,14 +28,17 @@ def FindERG( data, depth=2, sort_num=20):
     sort_num:int
     	The size of the  peendogenous reference gener filter
     	When the sample is large, it is recommended to increase the value
+    verbose: bool
+        Make the function noisy, writing times and results.
     Returns
     -------
     result:list
         a list of endogenous reference gene
     '''
     lp=[]
-    import time,datetime
-    start = time.time()
+    if verbose:
+        import time,datetime
+        start = time.time()
     if depth==1:
         print('the depth must larger than 2')
         return
@@ -85,9 +88,10 @@ def FindERG( data, depth=2, sort_num=20):
         if(count>1):
             result=list(set(testlist).intersection(set(result))) #Venn
     example = from_memberships(lp,data=range(len(lp)))
-    end = time.time()
-    print("calculate time:%.2fs"%(end-start))
-    print(result)
+    if verbose:
+        end = time.time()
+        print("calculate time:%.2fs"%(end-start))
+        print(result)
     if depth>2:
         plot(example)
     return result

--- a/ERgene/__init__.py
+++ b/ERgene/__init__.py
@@ -7,7 +7,6 @@ Revised on Thur Mar 18 16:04:00 2021
 
 New Version 1.2.3
 """
-
 import itertools
 import numpy as np
 import pandas as pd
@@ -15,11 +14,10 @@ from upsetplot import from_memberships
 from upsetplot import plot
 
 
-
 def FindERG( data, depth=2, sort_num=20):
     '''
     Find out endogenous reference gene
-    
+
     Parameters
     ----------
     data:pandas.DataFrmae
@@ -29,7 +27,7 @@ def FindERG( data, depth=2, sort_num=20):
         The larger the number, the fewer genes are screened out,Accuracy improvement
     sort_num:int
     	The size of the  peendogenous reference gener filter
-    	When the sample is large, it is recommended to increase the value	      
+    	When the sample is large, it is recommended to increase the value
     Returns
     -------
     result:list
@@ -49,18 +47,16 @@ def FindERG( data, depth=2, sort_num=20):
         return
     count=0
     result=[]#result
+    bucket_size = 1000
     for i in itertools.combinations(data.columns[0:depth], 2):
         start = time.time()
         count=count+1
         test=data.replace(0,np.nan).dropna()
 
         last_std=pd.DataFrame()
-        length=len(data)//1000
-        remain=len(data)-1000*length
-        for k in range(1,length+1):  
-
-            test1=test[i[0]].iloc[1000*(k-1):1000*k]
-            test2=test[i[1]].iloc[1000*(k-1):1000*k]
+        for k in range(0 ,len(data), bucket_size):
+            test1=test[i[0]].iloc[k:k + bucket_size]
+            test2=test[i[1]].iloc[k:k + bucket_size]
             data_len=len(test1.values)
             table1=np.array(test1.values.tolist()*data_len).reshape(data_len,data_len)
             table2=pd.DataFrame(table1.T/table1)
@@ -73,30 +69,10 @@ def FindERG( data, depth=2, sort_num=20):
             table6=(table2-table5).std()
             table6.index=test1.index
             l_std=table6.sort_values()[0:sort_num]
-            if(k==1):
+            if(k==0):
                 last_std=l_std
             else:
                 last_std=pd.concat([last_std,l_std])
-
-        test1=test[i[0]].iloc[length*1000:length*1000+remain]
-        test2=test[i[1]].iloc[length*1000:length*1000+remain]
-        data_len=len(test1.values)
-        table1=np.array(test1.values.tolist()*data_len).reshape(data_len,data_len)
-        table2=pd.DataFrame(table1.T/table1)
-        table2.index=test1.index
-
-        table4=np.array(test2.values.tolist()*data_len).reshape(data_len,data_len)
-        table5=pd.DataFrame(table4.T/table4)
-        table5.index=test1.index
-
-        table6=(table2-table5).std()
-        table6.index=test1.index
-        l_std=table6.sort_values()[0:sort_num]
-
-        if(k==1):
-            last_std=l_std
-        else:
-            last_std=pd.concat([last_std,l_std])
 
         last_std=last_std.sort_values()[0:sort_num]
 
@@ -113,21 +89,21 @@ def FindERG( data, depth=2, sort_num=20):
     print("calculate time:%.2fs"%(end-start))
     print(result)
     if depth>2:
-            plot(example)
+        plot(example)
     return result
 
 
 def normalizationdata( data, ERGname):
     '''
     Get a DataFrame disposed by standardization
-    
+
     Parameters
     ----------
     data:pandas.DataFrmae
         DataFrame of data points with each entry in the form:['gene_id','sample1',...]
     ERGname:str
         the gene use to normalization
-          
+
     Returns
     -------
     result:pandas.DataFrame
@@ -137,10 +113,3 @@ def normalizationdata( data, ERGname):
     da=data.iloc[:,0:len(data.columns)]/np.asarray(l.iloc[0,0:len(data.columns)])
     da=da*l.iloc[0,0]
     return da
-
-            
-        
-        
-        
-        
-


### PR DESCRIPTION
Description
---------------
FindERG was chunking the data in buckets of 1000 rows, but the first chunk was skipped. Thus, if the data has less than 1000 rows, k isn't defined further down and the code failed.

Code that processed the last chunk was repeated, and with this refactoring can be removed.

Also, a "verbose" parameter was added to the signature to allow the function to run silent.

POC
------

    data=pd.read_csv('example/gse.txt',sep='\t') # GSE125792
    data=data.set_index(data.columns[0]) # This is Ver1.2

    FindERG(data, 3)  # Worked as expected

    data = data.head(999)

    FindERG(data,3)  # Failed